### PR TITLE
Added flyway migration setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Flyway
+flyway.conf

--- a/db/migrations/V1__create_profiles.sql
+++ b/db/migrations/V1__create_profiles.sql
@@ -1,0 +1,11 @@
+CREATE TYPE user_role AS ENUM ('customer', 'vendor', 'admin');
+CREATE TYPE vendor_status AS ENUM ('pending', 'approved', 'suspended');
+
+CREATE TABLE profiles (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  auth0_id VARCHAR(255) UNIQUE NOT NULL,
+  role user_role NOT NULL DEFAULT 'customer',
+  vendor_status vendor_status,
+  created_at TIMESTAMP DEFAULT NOW(),
+  name VARCHAR(32)
+);

--- a/flyway.conf.example
+++ b/flyway.conf.example
@@ -1,0 +1,5 @@
+flyway.url=jdbc:postgresql://<your-azure-host>:5432/<your-db-name>?sslmode=require
+flyway.user=
+flyway.password=
+flyway.locations=filesystem:db/migrations
+flyway.baselineOnMigrate=true


### PR DESCRIPTION
I finished setting up the database migration tool. We will be using Flyway, it is a way of managing schema changes and keeping track of how our database evolves. (I will explain how this will work going forward and how everyone can set it up on their machines)

## Purpose
Managing schema changes through migration files ensures every team member's database stays in sync, it is technically apart of the CI/CD pipeline (we will sort this out). 

## What is included
- `db/` folder at the root of the repo
- `migrations/` folder under `db/` (this folder contains the baseline migration -- the queries that were run to get the database to where it is at the time of implementing the tool)
- `flyway.conf.example` at the root of the repo (use this as a template to create your own `flyway.conf`)
- `flyway.conf` added to the root `.gitignore` so credentials are never committed
- Root level `.gitignore` created to cover repo-wide ignored files, because I noticed the only one we had was in the frontend folder.
