### PR TITLE
Expand vendor fields, reorder routes, fix uploads

### DIFF
--- a/backend/src/modules/uploads/uploads.routes.ts
+++ b/backend/src/modules/uploads/uploads.routes.ts
@@ -17,7 +17,7 @@ router.get('/sign', (req: Request, res: Response) => {
 
   // resource_type is NEVER included in the signature params
   // it only goes in the upload URL and FormData
-  const signParams: Record<string, any> = { timestamp, folder,  type: 'upload', };
+  const signParams: Record<string, any> = { timestamp, folder };
 
   const signature = cloudinary.utils.api_sign_request(
     signParams,

--- a/backend/src/modules/vendors/vendor.repository.ts
+++ b/backend/src/modules/vendors/vendor.repository.ts
@@ -19,7 +19,18 @@ export const getAllVendors = async () => {
 // Fetch a single vendor by their ID
 export const getVendorById = async (id: string) => {
   const result = await pool.query(`
-    SELECT v.id, v.description, v.is_active, v.logo_url, p.name
+    SELECT 
+      v.id,
+      v.vendor_name,
+      v.description,
+      v.category,
+      v.location,
+      v.operating_hours,
+      v.logo_url,
+      v.banner_url,
+      v.status,
+      v.is_active,
+      p.name AS owner_name
     FROM vendors v
     JOIN profiles p ON v.profile_id = p.id
     WHERE v.id = $1

--- a/backend/src/modules/vendors/vendors.routes.ts
+++ b/backend/src/modules/vendors/vendors.routes.ts
@@ -5,12 +5,12 @@ import {
   approveApplicationHandler,
   rejectApplicationHandler,
 } from './vendor.controller';
+
 const router = Router();
 
+// Admin
 router.post('/applications/:id/approve', approveApplicationHandler);
 router.post('/applications/:id/reject', rejectApplicationHandler);
-
-//admin
 router.get('/applications/pending', vendorController.getPendingApplications);
 router.get('/admin/all', vendorController.getAllVendorsAdmin);
 router.patch('/:id/status', vendorController.updateVendorStatus);
@@ -20,16 +20,15 @@ router.get('/', vendorController.getAllVendors);
 router.post('/applications', vendorController.submitVendorApplication);
 router.post('/register', vendorController.registerVendor);
 router.post('/status', vendorController.checkVendorStatus);
-router.get('/:id', vendorController.getVendorById);       // ← wildcard routes last
-router.put('/:id', vendorController.updateVendor);        // ← wildcard routes last
 
-
-// Menu
+// Menu (must come before /:id wildcards)
 router.get('/:id/menu', vendorController.getVendorMenu);
 router.post('/:id/menu', vendorController.createMenuItem);
 router.put('/:id/menu/:itemId', vendorController.updateMenuItem);
 router.delete('/:id/menu/:itemId', vendorController.deleteMenuItem);
 
-
+// Wildcards last
+router.get('/:id', vendorController.getVendorById);
+router.put('/:id', vendorController.updateVendor);
 
 export default router;

--- a/frontend/src/pages/vendor/VendorSettings.jsx
+++ b/frontend/src/pages/vendor/VendorSettings.jsx
@@ -123,7 +123,7 @@ export default function VendorSettings() {
           operating_hours: hoursRaw,
           phone: vendorInfo.phone || '',
           email: vendorInfo.email || '',
-          image_url: vendorInfo.image_url || null,
+          image_url: vendorInfo.banner_url || null,
           logo_url: vendorInfo.logo_url || null,
         });
       }
@@ -181,7 +181,7 @@ export default function VendorSettings() {
     formData.append('timestamp', timestamp);
     formData.append('signature', signature);
     formData.append('api_key', apiKey);
-    formData.append('folder', 'orderup/menu-items');
+    formData.append('folder', 'folder');//folder line
     const uploadRes = await fetch(
       `https://api.cloudinary.com/v1_1/${cloudName}/image/upload`,
       { method: 'POST', body: formData }
@@ -307,10 +307,6 @@ export default function VendorSettings() {
             // image_url: vendorData.image_url,
           }),
         });
-        // ADD THIS before the if (updateRes.ok) check
-        const updateData = await updateRes.json();
-        console.log('Update response status:', updateRes.status);
-        console.log('Update response body:', updateData);
 
         if (updateRes.ok) {
           setShowSuccess(true);
@@ -330,7 +326,6 @@ export default function VendorSettings() {
       setSaving(false);
     }
   };
-  
 
   // ── Input style helpers ────────────────────────────────────────────────────
   const inputStyle = {


### PR DESCRIPTION
Backend: expand getVendorById SELECT to return more vendor fields (vendor_name, category, location, operating_hours, banner_url, status) and alias the owner as owner_name. Adjust uploads signing to omit the extra 'type' param. Reorder vendors.routes to place menu routes before wildcard /:id handlers and move wildcard routes to the end to avoid route conflicts; add clarifying comments. Frontend: VendorSettings now uses banner_url for the main image, updates the Cloudinary form 'folder' value (placeholder), and removes leftover debug logging. These changes ensure full vendor data exposure, correct routing order, and consistent upload/signing behavior.